### PR TITLE
add Dockerfile for testing and deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.ipynb_checkpoints/
+tmp/
+.git/
+README.md
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.7.0
+MAINTAINER "chestercheng <chester7864@gmail.com>"
+
+# Install requirements
+RUN pip install matplotlib==3.0.0
+RUN pip install numpy==1.15.3
+RUN pip install ipykernel==5.1.0
+RUN pip install ipython==7.0.1
+RUN pip install jupyter==1.0.0
+RUN pip install jupyter-contrib-nbextensions==0.5.0
+
+# Intstall jupyter extensions
+RUN jupyter contrib nbextension install --system
+RUN jupyter nbextension enable runtools/main
+
+# Add Tini. Tini operates as a process subreaper for jupyter. This prevents
+# kernel crashes.
+ENV TINI_VERSION=v0.6.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
+    /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# Create a non-root user
+ENV NB_USR=pyusr \
+    NB_GRP=pyhug
+RUN groupadd -r ${NB_GRP}
+RUN useradd --no-log-init --create-home -r -g ${NB_GRP} ${NB_USR}
+
+# Running jupyter notebook as non-root user
+USER ${NB_USR}
+EXPOSE 8888
+WORKDIR /home/${NB_USR}
+ADD * ./
+CMD ["jupyter", "notebook", "--port=8888", "--no-browser", "--ip=0.0.0.0"]


### PR DESCRIPTION
As title

The docker image include [` runtools `](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/runtools) extension, we can run all the cells in a notebook and skip over any exceptions.

And if anyone try to play with this project on localhost, they can run the following commands to setup the environment.

```
$ docker build --no-cache -t first_day_with_python .
$ docker run -it --name first_day_with_python -p 8888:8888 first_day_with_python
[I 13:50:22.387 NotebookApp] Writing notebook server cookie secret to /home/pyusr/.local/share/jupyter/runtime/notebook_cookie_secret
[I 13:50:22.657 NotebookApp] [jupyter_nbextensions_configurator] enabled 0.4.0
[I 13:50:22.658 NotebookApp] Serving notebooks from local directory: /home/pyusr
[I 13:50:22.658 NotebookApp] The Jupyter Notebook is running at:
[I 13:50:22.659 NotebookApp] http://(d782eaf6181a or 127.0.0.1):8888/?token=684796fcaa9594160bfc56ae3bdb0314c9c40c316df07dc6
[I 13:50:22.659 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[C 13:50:22.660 NotebookApp]

    Copy/paste this URL into your browser when you connect for the first time,
    to login with a token:
        http://(d782eaf6181a or 127.0.0.1):8888/?token=684796fcaa9594160bfc56ae3bdb0314c9c40c316df07dc6
```