### PR TITLE
set docker container timezone to Asia/Taipei

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,14 @@ USER root
 RUN pip install 'matplotlib==3.0.0' && \
     pip install 'numpy==1.15.3' && \
     pip install 'jupyter-contrib-nbextensions==0.5.0'
-RUN jupyter contrib nbextension install --system && \
-    jupyter nbextension enable runtools/main
+RUN jupyter contrib nbextension install --system
 RUN fix-permissions $CONDA_DIR
 
+# Set Timezone
+ENV TZ=Asia/Taipei
+RUN apt-get update && apt-get install -y tzdata && rm /etc/localtime
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Enable 'runtools' extension
 USER $NB_USER
+RUN jupyter nbextension enable runtools/main


### PR DESCRIPTION
#### SUMMARY

* Setting timezone with ` tzdata ` package in docker container.

   Fixes [#22](https://github.com/yungyuc/first_day_with_python/issues/22)

* Run ` jupyter nbextension enable runtools/main `  as ` $NB_USER `

   I think the command only affected by execution user, maybe it will works execute as ` $NB_USER ` ...

#### COMPONENT NAME

Dockerfile